### PR TITLE
[FIX] Add error notification at Drag n Drop welcome dialogue attention grabber

### DIFF
--- a/src/components/form/DragDropInput.vue
+++ b/src/components/form/DragDropInput.vue
@@ -3,10 +3,24 @@
     <label v-if="label" :for="id" class="text-text-subtitle mb-2 block text-sm font-medium">
       {{ label }}
     </label>
-    <div :class="dropZoneClasses" @drop="handleDrop" @dragover="handleDragOver" @dragenter="handleDragEnter"
-      @dragleave="handleDragLeave" @click="triggerFileInput">
-      <input ref="fileInput" :id="id" type="file" :multiple="multiple" :accept="accept" @change="handleFileSelect"
-        class="hidden" :disabled="isUploading" />
+    <div
+      :class="dropZoneClasses"
+      @drop="handleDrop"
+      @dragover="handleDragOver"
+      @dragenter="handleDragEnter"
+      @dragleave="handleDragLeave"
+      @click="triggerFileInput"
+    >
+      <input
+        ref="fileInput"
+        :id="id"
+        type="file"
+        :multiple="multiple"
+        :accept="accept"
+        @change="handleFileSelect"
+        class="hidden"
+        :disabled="isUploading"
+      />
 
       <!-- Upload Icon -->
       <div class="flex flex-col items-center justify-center py-6">
@@ -24,34 +38,62 @@
 
     <!-- details -->
     <div class="mt-2 flex items-center justify-between">
-      <span class="text-xs font-normal text-gray-800">Supported File: {{ acceptText || 'PNG, JPG, GIF up to 10MB'
-      }}</span>
-      <span class="text-xs font-normal text-gray-800">Maximum Size: {{ formatFileSize(maxSize) }}</span>
+      <span class="text-xs font-normal text-gray-800"
+        >Supported File: {{ acceptText || 'PNG, JPG, GIF up to 10MB' }}</span
+      >
+      <span class="text-xs font-normal text-gray-800"
+        >Maximum Size: {{ formatFileSize(maxSize) }}</span
+      >
     </div>
 
     <!-- File List -->
     <div v-if="files.length > 0" class="mt-4 space-y-2">
-      <div v-for="(file, index) in files" :key="index"
-        class="flex items-center justify-between rounded-lg border border-gray-500 bg-transparent p-3">
+      <div
+        v-for="(file, index) in files"
+        :key="index"
+        class="flex items-center justify-between rounded-lg border border-gray-500 bg-transparent p-3"
+      >
         <div class="flex items-center space-x-3">
           <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
           </svg>
           <div>
             <p class="text-sm font-medium text-gray-900">{{ file.name }}</p>
             <p class="text-xs text-gray-500">{{ formatFileSize(file.size) }}</p>
           </div>
         </div>
-        <button @click="removeFile(index)"
+        <button
+          @click="removeFile(index)"
           class="flex items-center justify-center p-1 text-red-500 hover:cursor-pointer hover:text-red-700 disabled:cursor-default"
-          type="button" :disabled="props.isUploading">
+          type="button"
+          :disabled="props.isUploading"
+        >
           <ErrorIcon v-if="!props.isUploading" :size="24" class="text-red-500" />
           <div v-if="props.isUploading" class="relative">
-            <svg class="h-5 w-5 animate-spin text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none"
-              viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-              <path class="opacity-75" fill="currentColor" d="m12 2a10 10 0 0 1 10 10h-2a8 8 0 0 0-8-8v-2z"></path>
+            <svg
+              class="h-5 w-5 animate-spin text-green-600"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="m12 2a10 10 0 0 1 10 10h-2a8 8 0 0 0-8-8v-2z"
+              ></path>
             </svg>
           </div>
         </button>
@@ -167,10 +209,7 @@ const processFiles = (newFiles: File[]) => {
   for (const file of newFiles) {
     // Check file size
     if (file.size > props.maxSize) {
-      emit(
-        'error',
-        `File "${file.name}" is too large. Maximum size is ${formatFileSize(props.maxSize)}.`
-      );
+      emit('error', `File size must not exceed ${formatFileSize(props.maxSize)} MB.`);
       continue;
     }
 

--- a/src/features/widget-builder/WelcomeDialog.vue
+++ b/src/features/widget-builder/WelcomeDialog.vue
@@ -260,13 +260,24 @@ watch(
             v-model="welcomeDialogState.isAttentionGrabberImage"
           >
             <DragDropInput
-              :accept="ACCEPTED_IMAGE_TYPES.PNG_JPG"
               acceptText="PNG or JPG"
+              :accept="ACCEPTED_IMAGE_TYPES.PNG_JPG"
               :maxSize="FILE_SIZE_LIMITS.IMAGE_EXTRA_LARGE"
               :maxFiles="1"
               :isUploading="attentionGrabberImageUpload.loading.value"
               @upload="(files) => files[0] && handleImageUpload(files[0], 'attentionGrabberImage')"
+              @error="(e) => (attentionGrabberImageUpload.error.value = new Error(e))"
             />
+            <Banner
+              v-if="attentionGrabberImageUpload.error.value"
+              intent="negative"
+              size="small"
+              class="mt-2"
+            >
+              <p>
+                {{ attentionGrabberImageUpload.error.value }}
+              </p>
+            </Banner>
           </OptionalInput>
           <OptionalInput
             id="attention-grabber-switch"


### PR DESCRIPTION
- Add error notification at Drag n Drop welcome dialogue attention grabber

<img width="1919" height="1021" alt="image" src="https://github.com/user-attachments/assets/ee6db065-e0bd-44c2-bd5d-52debfe6bb79" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user feedback for the "Attention Grabber" image upload, displaying clear error messages when upload issues occur.

* **Style**
  * Reformatted form input markup for better readability without changing functionality.

* **Refactor**
  * Simplified error messages for files exceeding the maximum upload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->