### PR TITLE
[FIX] Fixing some ticket 

### DIFF
--- a/src/features/widget-builder/channels/Channels.vue
+++ b/src/features/widget-builder/channels/Channels.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 
+import { Banner } from '@/components/common/common';
 import ImageInput from '@/components/form/ImageInput.vue';
 import Input from '@/components/form/Input.vue';
 import TextArea from '@/components/form/TextArea.vue';
@@ -10,7 +11,6 @@ import { useSweetAlert } from '@/composables/useSweetAlert';
 import WidgetFormLayout from '@/features/widget-builder/components/layout/WidgetFormLayout.vue';
 import { useQiscusLiveChatStore } from '@/stores/integration/qiscus-live-chat';
 
-import { Banner } from '@/components/common/common';
 import ChannelListCard from './components/ChannelListCard.vue';
 import PreviewChannels from './components/PreviewChannels.vue';
 
@@ -20,14 +20,14 @@ const { loading, data, error, upload } = useUploadSdkImage();
 const { channelState, channelList } = storeToRefs(useQiscusLiveChatStore());
 
 // Validates if the Live Chat toggle can be disabled
-const canDisableLiveChat = computed(() => {
-  return channelList.value.length > 0;
+const hasNoEnabledChannels = computed(() => {
+  return channelList.value.length === 0 || channelList.value.every((channel) => !channel.is_enable);
 });
 
 // Handles the toggle state change for Qiscus Live Chat
 const handleQiscusLiveChatToggle = async (newValue: boolean): Promise<void> => {
   // If trying to disable (newValue is false) and channelList is empty
-  if (!newValue && !canDisableLiveChat.value) {
+  if (!newValue && hasNoEnabledChannels.value) {
     await showAlert.error({
       title: 'Channel cannot be disabled.',
       text: 'You need to activate at least one additional channel before you can disable the Live Chat Widget.',
@@ -51,30 +51,69 @@ const uploadImage = async (file: File) => {
 </script>
 
 <template>
-  <div class="flex w-full flex-col lg:flex-row items-start gap-8 self-stretch">
+  <div class="flex w-full flex-col items-start gap-8 self-stretch lg:flex-row">
     <!-- Form Section -->
     <div class="flex w-full flex-1 flex-col gap-8">
-      <WidgetFormLayout id="channels-switch" label="Channels" isSwitch v-model="channelState.isChannelsEnabled">
+      <WidgetFormLayout
+        id="channels-switch"
+        label="Channels"
+        isSwitch
+        v-model="channelState.isChannelsEnabled"
+      >
         <template #inputs>
-          <Input id="welcome-channel-title" v-model="channelState.previewTitle" class="w-full"
-            label="Welcome Channel Title" placeholder="Ask for Question" :maxlength="50" />
+          <Input
+            id="welcome-channel-title"
+            v-model="channelState.previewTitle"
+            class="w-full"
+            label="Welcome Channel Title"
+            placeholder="Ask for Question"
+            :maxlength="50"
+          />
 
-          <Input id="welcome-channel-subtitle" v-model="channelState.previewSubtitle" class="w-full"
-            label="Welcome Channel Subtitle" placeholder="In Everythings!" :maxlength="50" />
-          <TextArea id="channel-introduction" v-model="channelState.previewIntroduction" label="Channel Introduction"
-            placeholder="More personalized chat with us on:" :maxlength="50" />
+          <Input
+            id="welcome-channel-subtitle"
+            v-model="channelState.previewSubtitle"
+            class="w-full"
+            label="Welcome Channel Subtitle"
+            placeholder="In Everythings!"
+            :maxlength="50"
+          />
+          <TextArea
+            id="channel-introduction"
+            v-model="channelState.previewIntroduction"
+            label="Channel Introduction"
+            placeholder="More personalized chat with us on:"
+            :maxlength="50"
+          />
         </template>
       </WidgetFormLayout>
 
-      <WidgetFormLayout v-if="channelState.isChannelsEnabled" label="Enable Qiscus Live Chat" isSwitch
-        :model-value="channelState.isQiscusLiveChat" @update:model-value="handleQiscusLiveChatToggle"
-        id="qiscus-live-chat-switch">
+      <WidgetFormLayout
+        v-if="channelState.isChannelsEnabled"
+        label="Enable Qiscus Live Chat"
+        isSwitch
+        :model-value="channelState.isQiscusLiveChat"
+        @update:model-value="handleQiscusLiveChatToggle"
+        id="qiscus-live-chat-switch"
+      >
         <template #inputs>
-          <Input v-model="channelState.previewLiveChatName" class="w-full" label="Live Chat Name"
-            placeholder="Live Chat" :maxlength="50" id="live-chat-name" />
+          <Input
+            v-model="channelState.previewLiveChatName"
+            class="w-full"
+            label="Live Chat Name"
+            placeholder="Live Chat"
+            :maxlength="50"
+            id="live-chat-name"
+          />
 
-          <ImageInput label="Live Chat Badge" id="live-chat-badge" v-model="channelState.channelBadgeIcon"
-            :isUploading="loading" @upload="uploadImage" @error="(e) => (error = new Error(e))">
+          <ImageInput
+            label="Live Chat Badge"
+            id="live-chat-badge"
+            v-model="channelState.channelBadgeIcon"
+            :isUploading="loading"
+            @upload="uploadImage"
+            @error="(e) => (error = new Error(e))"
+          >
             <template #tips>
               <div class="text-sm font-normal text-gray-800">
                 We recommend an image of at least 360x360 pixels. You can upload images in JPG,

--- a/src/features/widget-builder/channels/components/ChannelListCard.vue
+++ b/src/features/widget-builder/channels/components/ChannelListCard.vue
@@ -13,6 +13,8 @@ import type { NormalizedOtherChannel } from '@/types/schemas/channels/qiscus-wid
 
 import ModalChannelList from './ModalChannelList.vue';
 
+const MAX_CHANNELS = 6;
+
 // --- Store ---
 const qiscusLiveChatStore = useQiscusLiveChatStore();
 
@@ -73,7 +75,7 @@ const deleteChannel = (channelId: number) => {
 };
 
 const isMaxChannel = computed(() => {
-  return qiscusLiveChatStore.channelList.length === 6;
+  return qiscusLiveChatStore.channelList.length === MAX_CHANNELS;
 });
 </script>
 

--- a/src/features/widget-builder/channels/components/ChannelListCard.vue
+++ b/src/features/widget-builder/channels/components/ChannelListCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import Button from '@/components/common/Button.vue';
 import DropdownMenu from '@/components/common/DropdownMenu.vue';
@@ -71,6 +71,10 @@ const deleteChannel = (channelId: number) => {
   qiscusLiveChatStore.removeChannel(channelId);
   closeAllDropdowns();
 };
+
+const isMaxChannel = computed(() => {
+  return qiscusLiveChatStore.channelList.length === 6;
+});
 </script>
 
 <template>
@@ -88,6 +92,7 @@ const deleteChannel = (channelId: number) => {
           class="text-text-primary gap-2 !px-0"
           @click="isModalOpen = true"
           disableAnimation
+          :disabled="isMaxChannel"
         >
           <Icon name="plus" :size="18" class="" />
           <span class="text-xs font-semibold"> Add More Channel </span>

--- a/src/features/widget-builder/pages/WidgetPreview.vue
+++ b/src/features/widget-builder/pages/WidgetPreview.vue
@@ -2,8 +2,10 @@
 import { onMounted, onUnmounted } from 'vue';
 
 import { useAppConfigStore } from '@/stores/app-config';
+import { useQiscusLiveChatStore } from '@/stores/integration/qiscus-live-chat';
 
 const { appId, widget, baseUrl } = useAppConfigStore();
+const { loginFormState } = useQiscusLiveChatStore();
 const isStaging = widget?.env === 'staging';
 const isLatest = widget?.env === 'latest';
 const iframeUrl = widget?.iframeUrl || '';
@@ -22,7 +24,7 @@ onMounted(() => {
     options: {
       channel_id: string | number;
       mobileBreakPoint: number;
-      extra_fields: never[];
+      extra_fields: string;
       [key: string]: any;
     };
     staging?: boolean;
@@ -30,7 +32,7 @@ onMounted(() => {
     options: {
       channel_id: channelId,
       mobileBreakPoint: 400,
-      extra_fields: [],
+      extra_fields: JSON.stringify(loginFormState.extraFields),
     },
   };
 
@@ -84,5 +86,4 @@ onUnmounted(() => {
   existingStyleLink?.remove();
 });
 </script>
-<template>
-</template>
+<template></template>

--- a/src/features/widget/pages/WidgetCode.vue
+++ b/src/features/widget/pages/WidgetCode.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Banner from '@/components/common/Banner.vue';
 import { useAppConfigStore } from '@/stores/app-config';
+import { useQiscusLiveChatStore } from '@/stores/integration/qiscus-live-chat';
 
 import CodeSnippet from '../components/forms/CodeSnippet.vue';
 
@@ -10,6 +11,7 @@ const props = defineProps<{
 }>();
 
 const { appId, widget, baseUrl } = useAppConfigStore();
+const { loginFormState } = useQiscusLiveChatStore();
 const isStaging = widget?.env === 'staging';
 const isLatest = widget?.env === 'latest';
 const iframeUrl = widget?.iframeUrl || '';
@@ -23,7 +25,7 @@ const jsCode = `
             options: {
               channel_id: ${props.channelId},
               mobileBreakPoint: 400,
-              extra_fields: [],
+              extra_fields: ${JSON.stringify(loginFormState.extraFields)},
               ${baseUrl ? `baseUrl: '${baseUrl}',` : ''}
               ${iframeUrl ? `qismoIframeUrl: '${iframeUrl}',` : ''}
               ${isLatest ? `appVersion: 'latest',` : ''}

--- a/src/stores/integration/qiscus-live-chat.ts
+++ b/src/stores/integration/qiscus-live-chat.ts
@@ -182,7 +182,7 @@ export const useQiscusLiveChatStore = defineStore('create-qiscus-live-chat', () 
 
     callToActionState.isWithText = widgetConfigData.value?.buttonHasText ?? defaults.isWithText;
     callToActionState.liveChatButtonText =
-      widgetConfigData.value?.loginFormButtonLabel ?? defaults.liveChatButtonText;
+      widgetConfigData.value?.buttonText ?? defaults.liveChatButtonText;
     //
     callToActionState.isWithIcon = widgetConfigData.value?.buttonHasIcon ?? defaults.isWithIcon;
     callToActionState.iconImage = widgetConfigData.value?.buttonIcon ?? defaults.iconImage;
@@ -219,7 +219,7 @@ export const useQiscusLiveChatStore = defineStore('create-qiscus-live-chat', () 
     loginFormState.firstDescription =
       widgetConfigData.value?.formGreet ?? defaults.firstDescription;
     loginFormState.formSubtitle = widgetConfigData.value?.formSubtitle ?? defaults.formSubtitle;
-    loginFormState.buttonText = widgetConfigData.value?.buttonText ?? defaults.buttonText;
+    loginFormState.buttonText = widgetConfigData.value?.loginFormButtonLabel ?? defaults.buttonText;
     loginFormState.extraFields = widgetConfigData.value?.extra_fields ?? [];
     loginFormState.customerIdentifier =
       widgetConfigData.value?.customerIdentifierInputType ?? defaults.customerIdentifier;
@@ -284,7 +284,7 @@ export const useQiscusLiveChatStore = defineStore('create-qiscus-live-chat', () 
           formGreet: loginFormState.firstDescription,
           formSecondGreet: loginFormState.secondDescription, //=> new data // formSecondGreet
           formSubtitle: loginFormState.formSubtitle,
-          buttonText: loginFormState.buttonText,
+          loginFormButtonLabel: loginFormState.buttonText, //=> wrong data
           customerIdentifierInputType: loginFormState.customerIdentifier,
           extra_fields: loginFormState.extraFields,
           loginBrandLogo: loginFormState.brandLogo, //=> new data
@@ -297,7 +297,7 @@ export const useQiscusLiveChatStore = defineStore('create-qiscus-live-chat', () 
           buttonHasText: callToActionState.isWithText,
           buttonHasIcon: callToActionState.isWithIcon,
           buttonIcon: callToActionState.iconImage || DEFAULT_IMAGE_PREVIEW.LOGIN_BRAND_ICON,
-          loginFormButtonLabel: callToActionState.liveChatButtonText,
+          buttonText: callToActionState.liveChatButtonText, //= wrong data
           borderRadius: callToActionState.borderRadius, //=> new data
 
           // channel widget data


### PR DESCRIPTION
- Update wrong data
- Add max 6 additional channel on channel widget builder and disable channel add more 
- when all channel list false, show pop up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Add More Channel" button is now disabled when the maximum of 6 channels is reached.

* **Bug Fixes**
  * Corrected the mapping of button text labels for call-to-action and login form buttons, ensuring labels display and save correctly.
  * Improved logic for disabling live chat, now preventing disabling when there are no enabled channels and providing clearer error alerts.

* **Style**
  * Enhanced template formatting for improved readability and consistency.

* **Enhancements**
  * Dynamically inject extra fields from the live chat login form state into the widget preview and initialization code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->