### PR TITLE
[FIX] Add reset function for all widget chat builder form 

### DIFF
--- a/src/components/ui/widget-preview/LoginForm.vue
+++ b/src/components/ui/widget-preview/LoginForm.vue
@@ -35,12 +35,15 @@ const { baseUrl } = useAppConfigStore();
 <template>
   <div class="text-navy-500 shadow-card-float flex w-[360px] flex-col rounded-4xl bg-white">
     <div class="flex-1 p-8">
+      <!-- HEADER PREVIEW -->
       <div v-if="!props.isChannelEnabled">
         <Image v-if="props.brandLogo" :src="props.brandLogo ?? ''" alt="Brand Logo" size="32" />
         <QiscusIcon v-else :size="32" />
         <div class="mt-6 text-2xl break-words">{{ props.title }}</div>
         <div class="text-2xl font-bold break-words">{{ props.subtitle }}</div>
       </div>
+
+      <!-- if channel enabled -->
       <div v-else>
         <ChevronLeftIcon :size="28" />
         <div class="text-surface-primary-blue mt-8 flex items-center gap-3 text-2xl font-semibold">
@@ -52,6 +55,7 @@ const { baseUrl } = useAppConfigStore();
         {{ props.description }}
       </div>
 
+      <!-- MAIN CONTENT PREVIEW -->
       <div class="mt-8 flex w-full flex-col gap-4">
         <div class="shadow-card flex w-full items-center gap-3 rounded-2xl px-3 py-4">
           <div class="rounded-lg bg-gray-100 p-[7px]">
@@ -92,8 +96,15 @@ const { baseUrl } = useAppConfigStore();
           :key="field.id"
           class="shadow-card flex w-full items-center gap-3 rounded-2xl px-3 py-4"
         >
-          <div class="rounded-lg bg-gray-100 p-[7px] max-h-[32px] max-w-[32px]">
-            <Image :height="18" :width="18" v-if="field.icon" :src="field.icon" alt="field.label" :fallback-src="`${baseUrl}/img/icons/${field.icon.toLowerCase()}.png`" />
+          <div class="max-h-[32px] max-w-[32px] rounded-lg bg-gray-100 p-[7px]">
+            <Image
+              v-if="field.icon"
+              :height="18"
+              :width="18"
+              :src="field.icon"
+              :fallback-src="`${baseUrl}/img/icons/${field.icon.toLowerCase()}.png`"
+              alt="field.label"
+            />
           </div>
           <input
             :type="field.type"

--- a/src/features/widget-builder/pages/WidgetLiveChat.vue
+++ b/src/features/widget-builder/pages/WidgetLiveChat.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type Component, computed, onMounted, ref, watch } from 'vue';
+import { type Component, computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import RoundedTab from '@/components/common/Tabs/RoundedTab.vue';
@@ -107,7 +107,7 @@ watch(
 );
 
 // Store integration
-const { postWidgetConfig, getWidgetConfig } = useWidgetConfig();
+const { postWidgetConfig, getWidgetConfig, resetAllStores } = useWidgetConfig();
 const { appId } = useAppConfigStore();
 const { showAlert } = useSweetAlert();
 const iframeSrc = ref(`${window.location.origin + window.location.pathname}/preview`);
@@ -168,6 +168,10 @@ onMounted(async () => {
   // Ensure id is string or number, not array
   const channelId = (Array.isArray(id) ? id[0] : id) as string;
   getWidgetConfig(appId, channelId);
+});
+
+onUnmounted(() => {
+  resetAllStores();
 });
 </script>
 

--- a/src/stores/integration/widget-builder/call-to-action.ts
+++ b/src/stores/integration/widget-builder/call-to-action.ts
@@ -41,11 +41,17 @@ export const useCallToActionStore = defineStore('call-to-action', () => {
     borderRadius: state.borderRadius, // Widget V5 Data
   });
 
+  const resetToDefaults = () => {
+    Object.assign(state, { ...WIDGET_DEFAULTS.CALL_TO_ACTION });
+    originalState.value = { ...WIDGET_DEFAULTS.CALL_TO_ACTION };
+  };
+
   return {
     state,
     isDirty,
     populateFromConfig,
     getPayloadData,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/channels.ts
+++ b/src/stores/integration/widget-builder/channels.ts
@@ -122,6 +122,13 @@ export const useChannelWidgetStore = defineStore('channel-widget', () => {
     },
   });
 
+  const resetToDefaults = () => {
+    Object.assign(widgetState, { ...WIDGET_DEFAULTS.CHANNEL_WIDGET });
+    originalWidgetState.value = { ...WIDGET_DEFAULTS.CHANNEL_WIDGET };
+    channelList.value = [];
+    originalChannelList.value = [];
+  };
+
   return {
     // Widget state
     widgetState,
@@ -141,5 +148,6 @@ export const useChannelWidgetStore = defineStore('channel-widget', () => {
     populateFromConfig,
     getPayloadData,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/chat.ts
+++ b/src/stores/integration/widget-builder/chat.ts
@@ -33,11 +33,17 @@ export const useChatStore = defineStore('chat', () => {
     customerServiceAvatar: state.customerServiceAvatar || CHANNEL_BADGE_URL.qiscus,
   });
 
+  const resetToDefaults = () => {
+    Object.assign(state, { ...WIDGET_DEFAULTS.CHAT });
+    originalState.value = { ...WIDGET_DEFAULTS.CHAT };
+  };
+
   return {
     state,
     isDirty,
     populateFromConfig,
     getPayloadData,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/color.ts
+++ b/src/stores/integration/widget-builder/color.ts
@@ -25,10 +25,16 @@ export const useColorWidgetStore = defineStore('color-widget', () => {
     updateOriginalState();
   };
 
+  const resetToDefaults = () => {
+    colorWidgetState.value = WIDGET_DEFAULTS.COLOR_WIDGET;
+    originalColorWidgetState.value = WIDGET_DEFAULTS.COLOR_WIDGET;
+  };
+
   return {
     colorWidgetState,
     isDirty,
     populateFromConfig,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/login-form.ts
+++ b/src/stores/integration/widget-builder/login-form.ts
@@ -1,15 +1,9 @@
 import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
 
-
-
 import type { ILoginFormState } from '@/types/live-chat';
 import type { LoginForm } from '@/types/schemas/channels/qiscus-widget/config-qiscus-widget';
 import { WIDGET_DEFAULTS } from '@/utils/constant/widget-default';
-
-
-
-
 
 export const useLoginFormStore = defineStore('login-form', () => {
   const state = reactive<ILoginFormState>({ ...WIDGET_DEFAULTS.LOGIN_FORM });
@@ -82,6 +76,11 @@ export const useLoginFormStore = defineStore('login-form', () => {
     loginBrandLogo: state.brandLogo,
   });
 
+  const resetToDefaults = () => {
+    Object.assign(state, { ...WIDGET_DEFAULTS.LOGIN_FORM });
+    originalState.value = { ...WIDGET_DEFAULTS.LOGIN_FORM };
+  };
+
   return {
     state,
     customerIdentifierOptions,
@@ -91,5 +90,6 @@ export const useLoginFormStore = defineStore('login-form', () => {
     populateFromConfig,
     getPayloadData,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/welcome-dialogue.ts
+++ b/src/stores/integration/widget-builder/welcome-dialogue.ts
@@ -59,11 +59,17 @@ export const useWelcomeDialogueStore = defineStore('welcome-dialogue', () => {
     attentionGrabberImage: state.attentionGrabberImage,
   });
 
+  const resetToDefaults = () => {
+    Object.assign(state, { ...WIDGET_DEFAULTS.WELCOME_DIALOG });
+    originalState.value = { ...WIDGET_DEFAULTS.WELCOME_DIALOG };
+  };
+
   return {
     state,
     isDirty,
     populateFromConfig,
     getPayloadData,
     updateOriginalState,
+    resetToDefaults,
   };
 });

--- a/src/stores/integration/widget-builder/widget-config.ts
+++ b/src/stores/integration/widget-builder/widget-config.ts
@@ -54,6 +54,15 @@ export const useWidgetConfig = () => {
     colorWidgetStore.updateOriginalState();
   };
 
+  const resetAllStores = () => {
+    welcomeDialogStore.resetToDefaults();
+    callToActionStore.resetToDefaults();
+    channelWidgetStore.resetToDefaults();
+    loginFormStore.resetToDefaults();
+    chatFormStore.resetToDefaults();
+    colorWidgetStore.resetToDefaults();
+  };
+
   const getWidgetConfig = async (appId: string, channelId: string) => {
     try {
       await fetchConfigWidget(appId, channelId);
@@ -108,5 +117,6 @@ export const useWidgetConfig = () => {
     postWidgetConfig,
     populateAllStores,
     updateAllOriginalStates,
+    resetAllStores,
   };
 };


### PR DESCRIPTION
<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/51ae3a9d-4943-4439-9884-e097138eaca8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to reset all widget configurations to their default settings from the live chat widget builder.
  * Introduced individual reset options for call-to-action, channel, chat, color, login form, and welcome dialogue widgets.

* **Refactor**
  * Improved code readability and structure in the login form preview UI without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->