### PR TITLE
refactor(bot-telegram): remove unnecessary nav button

### DIFF
--- a/src/views/integration/bot/BotView.vue
+++ b/src/views/integration/bot/BotView.vue
@@ -5,7 +5,7 @@ import { onMounted, reactive, ref, watch } from 'vue';
 import MainTab from '@/components/common/Tabs/MainTab.vue';
 import { Banner, Button, CollapsibleGroup, Image, Switch } from '@/components/common/common';
 import InputCustom from '@/components/form/InputCustom.vue';
-import { BackIcon, CopyIcon, HomeIcon } from '@/components/icons';
+import { BackIcon, CopyIcon } from '@/components/icons';
 import {
   useActivateBot,
   useFetchBot,
@@ -166,12 +166,6 @@ onMounted(async () => {
     <div class="flex items-center justify-between">
       <router-link to="/" id="route-integration" replace class="text-primary flex items-center gap-2 font-semibold">
         <BackIcon :size="20" />
-        Integration
-      </router-link>
-
-      <router-link to="/" id="route-back-integration" replace
-        class="text-primary flex items-center gap-2 font-semibold">
-        <HomeIcon :size="20" />
         Integration
       </router-link>
     </div>

--- a/src/views/integration/telegram/TelegramView.vue
+++ b/src/views/integration/telegram/TelegramView.vue
@@ -397,12 +397,6 @@ onMounted(async () => {
         <BackIcon :size="20" />
         Integration
       </router-link>
-
-      <router-link to="/" id="route-back-integration" replace
-        class="text-primary flex items-center gap-2 font-semibold">
-        <HomeIcon :size="20" />
-        Integration
-      </router-link>
     </div>
 
     <div class="mx-auto flex w-11/12 flex-col gap-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed duplicate navigation links to the integration home page from the bot and Telegram integration views, simplifying the navigation UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->